### PR TITLE
action variable

### DIFF
--- a/.github/workflows/magnifai.yml
+++ b/.github/workflows/magnifai.yml
@@ -3,8 +3,6 @@ name: Magnifai Request
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited, labeled]
-env:
-  MAGNIFAI_RESULT_ID: 64ab697d153fb55fb4caa174
 
 jobs:
   deployment:

--- a/.github/workflows/magnifai.yml
+++ b/.github/workflows/magnifai.yml
@@ -3,8 +3,6 @@ name: Magnifai Request
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited, labeled]
-env:
-  MAGNIFAI_RESULT_ID:
 
 jobs:
   deployment:
@@ -22,7 +20,7 @@ jobs:
         id: magifaiReq
         uses: fjogeleit/http-request-action@v1
         with:
-          url: https://42i.magnifai.es/aut-dashboard-api/results/${{env.MAGNIFAI_RESULT_ID}}
+          url: https://42i.magnifai.es/aut-dashboard-api/results/${{vars.MAGNIFAI_RESULT_ID}}
           method: "GET"
           bearerToken: ${{ fromJson(steps.authReq.outputs.response).access_token }}
           customHeaders: '{"Content-Type": "application/x-www-form-urlencoded"}'

--- a/.github/workflows/magnifai.yml
+++ b/.github/workflows/magnifai.yml
@@ -3,6 +3,8 @@ name: Magnifai Request
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited, labeled]
+env:
+  MAGNIFAI_RESULT_ID:
 
 jobs:
   deployment:


### PR DESCRIPTION
Removes the `MAGNIFAI_RESULT_ID` environment variable from the Magnifai workflow. 

The motivation behind this change is that the `MAGNIFAI_RESULT_ID` variable is no longer needed for the deployment process. It was initially used for a specific feature that has since been deprecated. Removing this variable streamlines the workflow and reduces unnecessary complexity.

Overall, this change improves the project by simplifying the Magnifai workflow and removing unused variables.